### PR TITLE
Swap single to double quote for certain titles

### DIFF
--- a/_posts/2021-03-21-its-the-simple-thangs.md
+++ b/_posts/2021-03-21-its-the-simple-thangs.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: 'It's the Simple Thangs'
+title: "It's the Simple Thangs"
 categories: [COVID-19, Thankfulness, Life, Death]
 ---
 My parent&#8217;s PPP loan came in yesterday. To celebrate, my mom went to Aldi&#8217;s and purchased some sweets and cheese. 

--- a/_posts/2021-03-29-netflix-and-tarantinos-hateful-8-a-short-review-and-thoughts-on-justice.md
+++ b/_posts/2021-03-29-netflix-and-tarantinos-hateful-8-a-short-review-and-thoughts-on-justice.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: 'Netflix and Tarantino's Hateful 8; A short Review and thoughts on Justice'
+title: "Netflix and Tarantino's Hateful 8; A short Review and thoughts on Justice"
 categories: [Hateful 8, Movie Reviews]
 ---
 The series is long. It&#8217;s absolutely a tour de force in the celebration of gore, violence, and hate. I finished it, despite the derogatory words eventually becoming tiresome to me.


### PR DESCRIPTION
Seems like single quotes in the title's attributes were causing errors. 